### PR TITLE
Added promise support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,35 +1,71 @@
 'use strict';
 
-
 /**
- * This function allows you to safely loop over a range of incrementing integers
- * in an asynchronous fashion.
- *
- * @method
- * @public
- *
- * @param {Integer} start - The number at which to start looping (inclusive).
- * @param {Integer} stop - The number at which to stop looping (exclusive).
- * @param {Function} callback - The callback to run at each iteration of the
- *   loop. The callback should have signature: callback(num) where num is the
- *   integer being processed.
- *  @param {Function} done - The OPTIONAL callback to run once the loop has been
- *    fully iterated over.
+ *  - The object exported contains two functions that simulate the for loop in an async fashion.
+ *  - The first function can be used with an ending callback which will be called in the last iteration,
+ *  - The second function returns a promise that will be resolved when the loop is over.
  */
-module.exports = function(start, stop, callback, done) {
-  var task, iterator;
-  var current = start;
 
-  iterator = function() {
-    if (current >= stop) {
-      clearInterval(task);
-      if (done) {
-        done();
+module.exports = {
+  /**
+   * This function allows you to safely loop over a range of incrementing integers
+   * in an asynchronous fashion.
+   *
+   * @method
+   * @public
+   *
+   * @param {Integer} start - The number at which to start looping (inclusive).
+   * @param {Integer} stop - The number at which to stop looping (exclusive).
+   * @param {Function} callback - The callback to run at each iteration of the
+   *   loop. The callback should have signature: callback(num) where num is the
+   *   integer being processed.
+   *  @param {Function} done - The OPTIONAL callback to run once the loop has been
+   *    fully iterated over.
+   */
+  for : function(start, stop, callback, done) {
+    var task, iterator;
+    var current = start;
+
+    task = setInterval(function() {
+      if (current >= stop) {
+        clearInterval(task);
+        if (done) {
+          done();
+        }
+      } else {
+        callback(current++);
       }
-    } else {
-      callback(current++);
-    }
-  }
+    }, 0);
+  },
 
-  task = setInterval(iterator, 0);
+  /**
+   * This function returns a promise of looping over a range of incrementing integers
+   * in an asynchronous fashion.
+   *
+   * @method
+   * @public
+   *
+   * @param {Integer} start - The number at which to start looping (inclusive).
+   * @param {Integer} stop - The number at which to stop looping (exclusive).
+   * @param {Function} callback - The callback to run at each iteration of the
+   *   loop. The callback should have signature: callback(num) where num is the
+   *   integer being processed.
+   */
+  promisedFor : function(start, stop, callback) {
+    return new Promise(function(resolve, reject){
+      var task, iterator;
+      var current = start;
+
+      iterator = function() {
+        if (current >= stop) {
+          clearInterval(task);
+          resolve(current);
+        } else {
+          callback(current++);
+        }
+      }
+
+      task = setInterval(iterator, 0);
+    });
+  }
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Async looping for Node.js.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha test"
   },
   "repository": {
     "type": "git",

--- a/test/functions/for.js
+++ b/test/functions/for.js
@@ -4,16 +4,17 @@
  * Dependencies.
  */
 var assert = require('assert');
-var lupus = require('..');
+var lupus  = require('../..');
 
 /**
  * Tests.
  */
-describe('lupus()', function() {
+describe('lupus.for()', function() {
+
   it('should increment the counter 10 times', function(done) {
     var counter = 0;
 
-    lupus(0, 10, function(n) {
+    lupus.for(0, 10, function(n) {
       counter++;
     }, function() {
       assert.equal(counter, 10);
@@ -22,8 +23,13 @@ describe('lupus()', function() {
   });
 
   it('should optionally accept a done callback', function(done) {
-    lupus(0, 10, function() {
-      done();
+    var counter = 0;
+
+    lupus.for(0, 10, function() {
+        counter++;
+        // callback is called only invoked in the last execution
+        if(counter === 10){ done(); }
     });
   });
+
 });

--- a/test/functions/promisedFor.js
+++ b/test/functions/promisedFor.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Dependencies.
+ */
+var assert = require('assert');
+var lupus  = require('../..');
+
+/**
+ * Tests.
+ */
+describe('lupus.promisedFor()', function() {
+  it('should get loop as promise and increment the counter 10 times', function() {
+    var counter = 0;
+    var promisedLoop = lupus.promisedFor(0, 10, function(n) { counter++; });
+
+    return promisedLoop.then(function(count){
+      assert.equal(counter, 10);
+      assert.equal(count, 10);
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,2 @@
+require('./functions/for.js');
+require('./functions/promisedFor.js');


### PR DESCRIPTION
Thought promise support could be useful too, so I changed the default exports for an object with functions one with the callback as it was and the other that returns a promise of looping over the defined range. As the type of loop is similar to the "for" loop, I just named the default as `.for()` and to add promise support just called the other one `.promisedFor()` . Also fixed the "should optionally accept a done callback" test which was getting an error of the `done()` callback being called more than once.